### PR TITLE
Added policy counter and reset button, fixed a bug with baseline outcome display

### DIFF
--- a/app/components/outcome.py
+++ b/app/components/outcome.py
@@ -206,7 +206,7 @@ class OutcomeComponent():
             Updates outcome plot when specific outcome is selected or context scatter point is clicked.
             """
             metrics_df = filter_metrics_json(metrics_json, metric_ranges)
-            cand_idxs = list(metrics_df.index)
+            cand_idxs = list(metrics_df.index)[:-1]  # So we don't include the baseline
 
             fig1 = self.plot_outcome_over_time(outcome1, outcomes_jsonl, cand_idxs)
             fig2 = self.plot_outcome_over_time(outcome2, outcomes_jsonl, cand_idxs)
@@ -223,5 +223,5 @@ class OutcomeComponent():
             Updates the available candidates in the link dropdown based on metric ranges.
             """
             metrics_df = filter_metrics_json(metrics_json, metric_ranges)
-            cand_idxs = list(metrics_df.index)
+            cand_idxs = list(metrics_df.index)[:-1]  # So we don't include the baseline
             return cand_idxs


### PR DESCRIPTION
Added a counter for how many policies were selected after the filter was applied.
Also hooked up a reset button to our slider reset callback.
Finally fixed a bug with the outcome plots where with the new filter function we would always show the baseline as cand 100 no matter what.