### PR TITLE
Fixed axis names for parallel coordinates

### DIFF
--- a/app/components/filter.py
+++ b/app/components/filter.py
@@ -27,6 +27,11 @@ class FilterComponent:
         with open("app/units.json", "r", encoding="utf-8") as f:
             self.units = json.load(f)
 
+        self.names_map = dict(zip(self.metrics, ["Temperature change from 1850",
+                                                 "Highest cost of energy",
+                                                 "Government spending",
+                                                 "Reduction in energy demand"]))
+
     def create_metric_sliders(self):
         """
         Creates initial metric sliders and lines them up with their labels.
@@ -48,17 +53,16 @@ class FilterComponent:
             )
             sliders.append(slider)
 
-        names_map = dict(zip(self.metrics, ["Temperature change from 1850",
-                                            "Highest cost of energy",
-                                            "Government spending",
-                                            "Reduction in energy demand"]))
         # w-25 and flex-grow-1 ensures they line up
         div = html.Div(
             children=[
                 html.Div(
                     className="d-flex flex-row mb-2",
                     children=[
-                        html.Label(f"{names_map[self.metrics[i]]} ({self.units[self.metrics[i]]})", className="w-25"),
+                        html.Label(
+                            f"{self.names_map[self.metrics[i]]} ({self.units[self.metrics[i]]})",
+                            className="w-25"
+                        ),
                         html.Div(sliders[i], className="flex-grow-1")
                     ]
                 )
@@ -79,6 +83,7 @@ class FilterComponent:
         fig = go.Figure()
 
         normalized_df = filter_metrics_json(metrics_json, metric_ranges, normalize=True)
+        normalized_df.rename(self.names_map, axis=1, inplace=True)
 
         cand_idxs = list(normalized_df.index)[:-1]  # Leave out the baseline
         n_special_cands = min(10, len(cand_idxs))


### PR DESCRIPTION
Used the same hard-coded mapping that we use to modify the filter sliders for the parallel coordinates.